### PR TITLE
feat: added support for trace-id generation and logging in polka

### DIFF
--- a/packages/polka/package.json
+++ b/packages/polka/package.json
@@ -31,6 +31,7 @@
     "compression": "^1.7.4",
     "cors": "^2.8.5",
     "helmet": "^6.0.1",
+    "nanoid": "^4",
     "polka": "^0.5.2",
     "rate-limiter-flexible": "^2.4.1",
     "serve-static": "^1.15.0",

--- a/packages/polka/src/ResponseError.ts
+++ b/packages/polka/src/ResponseError.ts
@@ -1,7 +1,6 @@
 import type http from 'node:http';
 
 import type { ITrace } from '@cortec/types';
-import { Headers } from '@cortec/types';
 
 import HttpStatusCode from './HttpStatusCodes';
 import send from './send';
@@ -50,22 +49,15 @@ export default class ResponseError<T = unknown> extends Error {
   send(res: http.ServerResponse, req: ITrace) {
     const traceId = req.trace.id;
 
-    return send(
-      res,
-      this.statusCode,
-      {
-        error: {
-          name: this.name,
-          message: this.injectTraceInMessage
-            ? `${this.message} (Trace Id: ${traceId})`
-            : this.message,
-          traceId: req.trace.id,
-          details: this.details,
-        },
+    return send(res, this.statusCode, {
+      error: {
+        name: this.name,
+        message: this.injectTraceInMessage
+          ? `${this.message} (Trace Id: ${traceId})`
+          : this.message,
+        traceId: req.trace.id,
+        details: this.details,
       },
-      {
-        [Headers.TRACE_ID]: traceId,
-      }
-    );
+    });
   }
 }

--- a/packages/polka/src/index.ts
+++ b/packages/polka/src/index.ts
@@ -108,20 +108,13 @@ export default class Polka implements IModule, IServerHandler {
         logger?.error(err);
 
         // Respond as internal server error
-        send(
-          res,
-          HttpStatusCode.INTERNAL_SERVER_ERROR,
-          {
-            error: {
-              name: 'InternalServerError',
-              message: 'Something went wrong on the server',
-              traceId: (req as Request).trace.id,
-            },
+        send(res, HttpStatusCode.INTERNAL_SERVER_ERROR, {
+          error: {
+            name: 'InternalServerError',
+            message: 'Something went wrong on the server',
+            traceId: (req as Request).trace.id,
           },
-          {
-            [Headers.TRACE_ID]: req.trace.id,
-          }
-        );
+        });
       },
 
       // Handle the case when no matching route was found

--- a/packages/polka/src/index.ts
+++ b/packages/polka/src/index.ts
@@ -11,9 +11,7 @@ import {
   type IContext,
   type IModule,
   type IServerHandler,
-  type ITrace,
   type Sig,
-  Headers,
 } from '@cortec/types';
 import bodyParser from 'body-parser';
 import type { CompressionOptions } from 'compression';
@@ -36,7 +34,8 @@ import { fromZodError } from 'zod-validation-error';
 import HttpStatusCode from './HttpStatusCodes';
 import ResponseError from './ResponseError';
 import send from './send';
-import type { IApp, IRouter, route } from './types';
+import type { IApp, IRouter, ITrace, route } from './types';
+import { Headers } from './types';
 
 type PolkaConfig = {
   cors: CorsOptions;
@@ -63,7 +62,7 @@ const methods = [
   'put',
 ] as const;
 
-export interface Request extends p.Request, ITrace {
+interface Request extends p.Request, ITrace {
   session?: unknown;
   body?: unknown;
 }
@@ -112,7 +111,7 @@ export default class Polka implements IModule, IServerHandler {
           error: {
             name: 'InternalServerError',
             message: 'Something went wrong on the server',
-            traceId: (req as Request).trace.id,
+            traceId: req.trace.id,
           },
         });
       },

--- a/packages/polka/src/types.ts
+++ b/packages/polka/src/types.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 
-import type { IContext, ITrace } from '@cortec/types';
+import type { IContext } from '@cortec/types';
 import type { Polka } from 'polka';
 import type querystring from 'querystring';
 import type { ServeStaticOptions } from 'serve-static';
@@ -118,3 +118,11 @@ export interface IApp extends Pick<Polka, 'use'> {
 }
 
 export type IRouter = (app: IApp, ctx: IContext) => void;
+
+export interface ITrace {
+  trace: { id: string };
+}
+
+export enum Headers {
+  TRACE_ID = 'x-trace-id',
+}

--- a/packages/polka/src/types.ts
+++ b/packages/polka/src/types.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 
-import type { IContext } from '@cortec/types';
+import type { IContext, ITrace } from '@cortec/types';
 import type { Polka } from 'polka';
 import type querystring from 'querystring';
 import type { ServeStaticOptions } from 'serve-static';
@@ -49,7 +49,7 @@ export interface IRoute<
     count(
       this: IContext,
       req: IRequest<ParamsT, QueryT, BodyT>,
-      ctx: ReqCtx & { session?: Session }
+      ctx: ReqCtx & { session?: Session } & ITrace
     ): string;
     keyPrefix?: string;
   };
@@ -63,7 +63,7 @@ export interface IRoute<
   onRequest(
     this: IContext,
     req: IRequest<ParamsT, QueryT, BodyT>,
-    ctx: ReqCtx & { session: Session }
+    ctx: ReqCtx & { session: Session } & ITrace
   ): Promise<IResponse<ResponseT>>;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,11 +25,3 @@ export interface IModule {
   load(ctx: IContext, sig: Sig): Promise<void>;
   dispose(): Promise<void>;
 }
-
-export interface ITrace {
-  trace: { id: string };
-}
-
-export enum Headers {
-  TRACE_ID = 'x-trace-id',
-}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,3 +25,11 @@ export interface IModule {
   load(ctx: IContext, sig: Sig): Promise<void>;
   dispose(): Promise<void>;
 }
+
+export interface ITrace {
+  trace: { id: string };
+}
+
+export enum Headers {
+  TRACE_ID = 'x-trace-id',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5948,6 +5948,11 @@ nan@^2.16.0:
   resolved "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz"
   integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
+nanoid@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.2.tgz#140b3c5003959adbebf521c170f282c5e7f9fb9e"
+  integrity sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==
+
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz"


### PR DESCRIPTION
This PR introduces the creation of traceId into each request

- If the incoming request header doesn't contain the trace-id, a new trace id is created
- The trace id is made part of every error that is emitted out of this service