### PR TITLE
fix: remove duplicate ssl field from elastic config

### DIFF
--- a/packages/elastic/src/index.ts
+++ b/packages/elastic/src/index.ts
@@ -23,6 +23,17 @@ export interface IElastic {
   client: (identity: string) => Client;
 }
 
+type ClientConfig = {
+  node: string;
+  auth: {
+    username: string;
+    password: string;
+  };
+  ssl?: {
+    ca: any;
+  };
+};
+
 export class Elastic implements IModule, IElastic {
   name = 'elastic';
   protected clients: { [identity: string]: Client } = {};
@@ -35,7 +46,7 @@ export class Elastic implements IModule, IElastic {
   async load(_: IContext, sig: Sig): Promise<void> {
     for (const [identity, { connection }] of Object.entries(this.config)) {
       const node = `${connection.host}:${connection.port}`;
-      const clientConfig = {
+      const clientConfig: ClientConfig = {
         node,
         auth: {
           username: connection.user,

--- a/packages/elastic/src/index.ts
+++ b/packages/elastic/src/index.ts
@@ -37,9 +37,6 @@ export class Elastic implements IModule, IElastic {
       const node = `${connection.host}:${connection.port}`;
       const clientConfig = {
         node,
-        ssl: {
-          ca: fs.readFileSync(connection.caFile),
-        },
         auth: {
           username: connection.user,
           password: connection.password,


### PR DESCRIPTION
This PR fixes the redundant inclusion of the `ssl` config field for the Elasticsearch client, which should only be added conditionally depending on whether the `caFile` field is set in the service config file.